### PR TITLE
add homebrew library folder as a default library folder

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,11 +57,17 @@ fn build() {
             .output()
             .unwrap();
         if !openssl_installed.status.success() {
-            panic!("OpenSSL not installed. To install `brew install openssl`");
+            panic!("OpenSSL is not installed. To install: `brew install openssl`");
         }
         let openssl = std::str::from_utf8(openssl_installed.stdout.as_slice())
             .unwrap()
             .trim();
+
+        // lz4
+        let lz4_installed = Command::new("brew").args(["list", "lz4"]).output().unwrap();
+        if !lz4_installed.status.success() {
+            panic!("liblz4 is not installed. To install: `brew install lz4`");
+        }
 
         // pkgconfig
         let pkgconfig_installed = Command::new("brew")
@@ -69,7 +75,7 @@ fn build() {
             .output()
             .unwrap();
         if !pkgconfig_installed.status.success() {
-            panic!("pkg-config not installed. To install `brew install pkgconfig`");
+            panic!("pkg-config is not installed. To install: `brew install pkgconfig`");
         }
 
         // libsodium
@@ -78,7 +84,7 @@ fn build() {
             .output()
             .unwrap();
         if !libsodium_installed.status.success() {
-            panic!("libsodium not installed. To install `brew install libsodium`");
+            panic!("libsodium is not installed. To install: `brew install libsodium`");
         }
         let libsodium = std::str::from_utf8(libsodium_installed.stdout.as_slice())
             .unwrap()
@@ -90,7 +96,7 @@ fn build() {
             .output()
             .unwrap();
         if !secp256k1_installed.status.success() {
-            panic!("secp256k1 not installed. To install `brew install secp256k1`");
+            panic!("secp256k1 is not installed. To install: `brew install secp256k1`");
         }
         let secp256k1 = std::str::from_utf8(secp256k1_installed.stdout.as_slice())
             .unwrap()
@@ -116,6 +122,7 @@ fn build_tonlibjson() {
     let dst = cmake::Config::new("ton")
         .configure_arg("-DTON_ONLY_TONLIB=true")
         .configure_arg("-DBUILD_SHARED_LIBS=false")
+        .configure_arg("-DCMAKE_EXE_LINKER_FLAGS=-L/opt/homebrew/lib")
         .define("TON_ONLY_TONLIB", "ON")
         .define("BUILD_SHARED_LIBS", "OFF")
         .configure_arg("-Wno-dev")


### PR DESCRIPTION
Since commit 6fe3a14b87342793ccf1eed42521e1b053534627 (up ton version, which introduced liblz4 library dependency) build fails on macos:
```
  1 warning generated.
  ld: library 'lz4' not found
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
 ```

 Short investigation shows ton build system doesn't set linking library folder correctly (I assume it's because of cross-dependencies, lz4 library folder can be overwritten by external modules)

 So basically it's `ton` library issue, but it can be fixed locally for `tonlib-sys`

 Also add liblz4 to dependency list in build.rs