### PR TITLE
feat: Expose emulator_set_verbosity_level, enabling ability to keep application log dry

### DIFF
--- a/src/tvm_emulator.rs
+++ b/src/tvm_emulator.rs
@@ -1,5 +1,13 @@
 extern "C" {
     /**
+     * @brief Set global verbosity level of the library
+     * @param verbosity_level New verbosity level (0 - never, 1 - error, 2 - warning, 3 - info, 4 - debug)
+     */
+    pub fn emulator_set_verbosity_level(
+        verbosity_level: u32,
+    ) -> bool;
+
+    /**
      * @brief Create TVM emulator
      * @param code_boc Base64 encoded BoC serialized smart contract code cell
      * @param data_boc Base64 encoded BoC serialized smart contract data cell

--- a/src/tvm_emulator.rs
+++ b/src/tvm_emulator.rs
@@ -3,9 +3,7 @@ extern "C" {
      * @brief Set global verbosity level of the library
      * @param verbosity_level New verbosity level (0 - never, 1 - error, 2 - warning, 3 - info, 4 - debug)
      */
-    pub fn emulator_set_verbosity_level(
-        verbosity_level: u32,
-    ) -> bool;
+    pub fn emulator_set_verbosity_level(verbosity_level: u32) -> bool;
 
     /**
      * @brief Create TVM emulator


### PR DESCRIPTION
Currently execution logs from VM are anyway being delivered to app stdout. Exposing this method, will make it optional.