### PR TITLE
Expose tvm_emulator_emulate_run_method

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn build_monorepo() {
     println!("cargo:rustc-link-lib=static=blst");
     // dynamic libs
     println!("cargo:rustc-link-lib=crypto"); // openssl
-    //println!("cargo:rustc-link-lib=dylib=z"); // zlib
+    println!("cargo:rustc-link-lib=dylib=z"); // zlib
     println!("cargo:rustc-link-lib=dylib=sodium");
     println!("cargo:rustc-link-lib=dylib=secp256k1");
     println!("cargo:rustc-link-search=native={build_dir}/build/third-party/crc32c");

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,9 @@ fn build_monorepo() {
     if cfg!(target_os = "linux") {
         println!("cargo:rustc-link-lib=dylib=stdc++");
         println!("cargo:rustc-link-arg=-lstdc++");
+        println!("cargo:rustc-env=CC=clang");
+        println!("cargo:rustc-env=CXX=clang++");
+        println!("cargo:rustc-env=CMAKE_CXX_STANDARD=17");
     }
 
     env::set_var("LD_LIBRARY_PATH", "lib/x86_64-linux-gnu");
@@ -111,6 +114,12 @@ fn run_build(target: &str) -> String {
     #[cfg(not(target_os = "macos"))]
     const APPLE: &str = "false";
 
+    let mut cxx_flags = "-w";
+    if cfg!(target_os = "linux") {
+        cxx_flags = "-w -std=c++17 --include=algorithm";
+    }
+
+
     let mut cfg = Config::new(TON_MONOREPO_DIR);
     let dst = cfg
         .define("BUILD_SHARED_LIBS", "false")
@@ -120,13 +129,13 @@ fn run_build(target: &str) -> String {
         .define("APPLE", APPLE)
         .define("CMAKE_BUILD_TYPE", CMAKE_BUILD_TYPE)
         .define("CMAKE_C_FLAGS", "-w")
-        .define("CMAKE_CXX_FLAGS", "-w")
+        .define("CMAKE_CXX_FLAGS", cxx_flags)
         .build_arg("-j")
         .build_arg(available_parallelism().unwrap().get().to_string())
         .configure_arg("-Wno-dev")
         .build_target(target)
         .always_configure(true)
-        .very_verbose(false);
+        .very_verbose(true);
 
     #[cfg(all(feature = "no_avx512", not(target_os = "macos")))]
     disable_avx512_for_gcc(dst);

--- a/build.rs
+++ b/build.rs
@@ -119,7 +119,6 @@ fn run_build(target: &str) -> String {
         cxx_flags = "-w -std=c++17 --include=algorithm";
     }
 
-
     let mut cfg = Config::new(TON_MONOREPO_DIR);
     let dst = cfg
         .define("BUILD_SHARED_LIBS", "false")

--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn build_monorepo() {
     println!("cargo:rustc-link-lib=static=blst");
     // dynamic libs
     println!("cargo:rustc-link-lib=crypto"); // openssl
-    println!("cargo:rustc-link-lib=dylib=z"); // zlib
+    //println!("cargo:rustc-link-lib=dylib=z"); // zlib
     println!("cargo:rustc-link-lib=dylib=sodium");
     println!("cargo:rustc-link-lib=dylib=secp256k1");
     println!("cargo:rustc-link-search=native={build_dir}/build/third-party/crc32c");

--- a/src/tvm_emulator.rs
+++ b/src/tvm_emulator.rs
@@ -95,6 +95,24 @@ extern "C" {
         stack_boc: *const std::os::raw::c_char,
     ) -> *const std::os::raw::c_char;
 
+
+    /**
+     * @brief Run get method with raw params
+     * @param len Length of params
+     * @param params_boc serialized params
+     * @param gas_limit Gas limit
+     * @return buffer with result length and result
+     * result is serialized cell chat contains:
+     * result.code: i32
+     * result.gas_used: i64
+     * vm stack: ref
+     */
+    pub fn tvm_emulator_emulate_run_method(
+        len: u32,
+        params_boc: *const std::os::raw::c_char,
+        gas_limit: i64,
+    ) -> *const std::os::raw::c_char;
+
     /**
      * @brief Send external message
      * @param tvm_emulator Pointer to TVM emulator

--- a/src/tvm_emulator.rs
+++ b/src/tvm_emulator.rs
@@ -95,7 +95,6 @@ extern "C" {
         stack_boc: *const std::os::raw::c_char,
     ) -> *const std::os::raw::c_char;
 
-
     /**
      * @brief Run get method with raw params
      * @param len Length of params


### PR DESCRIPTION
This method is necessary if you want to set smart contract code on C7 register and contract to have access to it.